### PR TITLE
Add SkiploverItemProgressionSpoilerLog

### DIFF
--- a/CondensedSpoilerLogger/Loggers/ItemProgressionSpoiler.cs
+++ b/CondensedSpoilerLogger/Loggers/ItemProgressionSpoiler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using RandomizerMod.Logging;
 using RandomizerMod.RC;
+using RandomizerMod.Settings;
 using RandomizerCore;
 using RandomizerCore.Logic;
 using RandomizerCore.Randomization;
@@ -218,8 +219,16 @@ namespace CondensedSpoilerLogger.Loggers
 
         public static List<List<ItemPlacement>> ComputeSkiploverPlacements(List<List<ItemPlacement>> spheredPlacements, RandoModContext ctx)
         {
-            // TODO: figure out how to enable All skips
-            RCUtil.SetupPM(ctx, out LogicManager lm, out ProgressionManager pm, out MainUpdater mu);
+            // enable All skips
+            GenerationSettings foolishGS = ctx.GenerationSettings.Clone() as GenerationSettings;
+            foolishGS.SkipSettings = RandomizerMod.Settings.Presets.SkipPresetData.Foolish.Clone() as SkipSettings;
+            foolishGS.Clamp();
+            RandoModContext foolishCtx = new(foolishGS, ctx.StartDef);
+            foolishCtx.notchCosts = ctx.notchCosts.ToList();
+            foolishCtx.itemPlacements = ctx.itemPlacements.ToList();
+            foolishCtx.transitionPlacements = ctx.transitionPlacements.ToList();
+            foolishCtx.Vanilla = ctx.Vanilla.ToList();
+            RCUtil.SetupPM(foolishCtx, out LogicManager lm, out ProgressionManager pm, out MainUpdater mu);
             
             List<List<ItemPlacement>> skiploverPlacements = new();
             

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ There is no guarantee that the order the items appear in this log reflects the o
 Note - the log generated is minimal in the sense that every item is required. However, it is possible that fewer items can be used in a different way;
 for instance, the log may list all stags besides Stag Nest Stag (which unlocks stag access to Stag Nest) and not Stag Nest Stag itself - none
 of these can be removed, even though the number of items in the log can be reduced.
+- SkiploverItemProgressionSpoilerLog: The same as the filtered spoiler, except each sphere includes locations that would be reachable with All skips enabled.
 - CollectedItemSpoiler: Collects locations with the same item and groups them together. Items which appear only once are placed
 at the bottom of the log.
 - CurrencySpoilerLog: Collects randomized currency items (geo, essence) and displays them ordered by amount.


### PR DESCRIPTION
Each Progression Sphere has the locations that would be reachable with All skips enabled, from the items available in-logic from previous Progression Spheres.

For example, in a seed calculated with not many skips, Sphere 4 might look like this in the `FilteredItemProgressionSpoilerLog`:
```
PROGRESSION SPHERE 4 (22 items)
Desolate_Dive <---at---> Geo_Rock-Abyss_2
Grimmkin_Flame <---at---> Whispering_Root-Resting_Grounds
Grimmkin_Flame <---at---> Whispering_Root-Mantis_Village
```

But look like this in the `SkiploverItemProgressionSpoilerLog`:
```
PROGRESSION SPHERE 4 (46 items)
Desolate_Dive <---at---> Geo_Rock-Abyss_2
Grimmkin_Flame <---at---> Whispering_Root-Resting_Grounds
Grimmkin_Flame <---at---> Whispering_Root-Mantis_Village
Mothwing_Cloak <---at---> Herrah (1 DREAMNAIL)
Simple_Key <---at---> Simple_Key-Lurker
```